### PR TITLE
#3 Select (slice) array by coordinate values

### DIFF
--- a/sdarray/__init__.py
+++ b/sdarray/__init__.py
@@ -10,6 +10,7 @@ DIMS = ("t", "ch")
 from . import config
 from . import arrayfact
 from . import arrayfunc
+from . import selector
 from . import accessor
 from .arrayfact import *
 from .arrayfunc import *

--- a/sdarray/accessor.py
+++ b/sdarray/accessor.py
@@ -29,6 +29,7 @@ def add_methods(module):
 
 @xr.register_dataarray_accessor(sd.ACCESSOR)
 @add_methods(sd.arrayfunc)
+@add_methods(sd.selector)
 class SDArrayAccessor:
     """DataArray accessor for an SD dataarray."""
 

--- a/sdarray/selector.py
+++ b/sdarray/selector.py
@@ -1,5 +1,7 @@
 __all__ = ["sel"]
 
+import numpy as np
+
 
 class SDArraySelector:
     def __init__(self, accessed, *coords):
@@ -17,6 +19,9 @@ class SDArraySelector:
 
     def _to_seq(self, values):
         return (values,) if len(self.coords) == 1 else values
+
+    def _to_unique(self, c, v, sep=","):
+        return [u for u in np.unique(c) if np.any(np.isin(v, u.split(sep)))]
 
     def eq(self, *values, drop=True):
         return self(lambda c, v: c.isin(v), *values, drop=drop)
@@ -38,6 +43,9 @@ class SDArraySelector:
 
     def between(self, *values, drop=True):
         return self(lambda c, v: (c >= v[0]) & (c <= v[1]), *values, drop=drop)
+
+    def contains(self, *values, drop=True):
+        return self(lambda c, v: c.isin(self._to_unique(c, v)), *values, drop=drop)
 
     def __eq__(self, values):
         """Helper operator for the `eq` method."""
@@ -66,6 +74,10 @@ class SDArraySelector:
     def __matmul__(self, values):
         """Helper operator for the `between` method."""
         return self.between(*self._to_seq(values))
+
+    def __pow__(self, values):
+        """Helper operator for the `contains` method."""
+        return self.contains(*self._to_seq(values))
 
 
 def sel(array, *coords):

--- a/sdarray/selector.py
+++ b/sdarray/selector.py
@@ -42,7 +42,7 @@ class SDArraySelector:
         return self(lambda c, v: c <= v, *values, drop=drop)
 
     def between(self, *values, drop=True):
-        return self(lambda c, v: (c >= v[0]) & (c <= v[1]), *values, drop=drop)
+        return self(lambda c, v: (c >= v[0]) & (c <= v[-1]), *values, drop=drop)
 
     def contains(self, *values, drop=True):
         return self(lambda c, v: c.isin(self._to_unique(c, v)), *values, drop=drop)

--- a/sdarray/selector.py
+++ b/sdarray/selector.py
@@ -3,7 +3,7 @@ __all__ = ["where"]
 import numpy as np
 
 
-class SDArrayFilter:
+class SDArraySelector:
     def __init__(self, accessed, *coords):
         self.accessed = accessed
         self.coords = coords
@@ -81,5 +81,5 @@ class SDArrayFilter:
 
 
 def where(array, *coords):
-    """Make an `SDArrayFilter` instance."""
-    return SDArrayFilter(array, *coords)
+    """Make an `SDArraySelector` instance."""
+    return SDArraySelector(array, *coords)

--- a/sdarray/selector.py
+++ b/sdarray/selector.py
@@ -1,9 +1,9 @@
-__all__ = ["sel"]
+__all__ = ["where"]
 
 import numpy as np
 
 
-class SDArraySelector:
+class SDArrayFilter:
     def __init__(self, accessed, *coords):
         self.accessed = accessed
         self.coords = coords
@@ -80,6 +80,6 @@ class SDArraySelector:
         return self.contains(*self._to_seq(values))
 
 
-def sel(array, *coords):
-    """Make an `SDArraySelector` instance."""
-    return SDArraySelector(array, *coords)
+def where(array, *coords):
+    """Make an `SDArrayFilter` instance."""
+    return SDArrayFilter(array, *coords)

--- a/sdarray/selector.py
+++ b/sdarray/selector.py
@@ -1,0 +1,73 @@
+__all__ = ["sel"]
+
+
+class SDArraySelector:
+    def __init__(self, accessed, *coords):
+        self.accessed = accessed
+        self.coords = coords
+
+    def __call__(self, evaluator, *values, drop=True):
+        selected = self.accessed
+
+        for coord, value in zip(self.coords, values):
+            condition = evaluator(selected[coord], value)
+            selected = selected.where(condition, drop=drop)
+
+        return selected
+
+    def _to_seq(self, values):
+        return (values,) if len(self.coords) == 1 else values
+
+    def eq(self, *values, drop=True):
+        return self(lambda c, v: c.isin(v), *values, drop=drop)
+
+    def neq(self, *values, drop=True):
+        return self(lambda c, v: ~c.isin(v), *values, drop=drop)
+
+    def gt(self, *values, drop=True):
+        return self(lambda c, v: c > v, *values, drop=drop)
+
+    def gt_or_eq(self, *values, drop=True):
+        return self(lambda c, v: c >= v, *values, drop=drop)
+
+    def lt(self, *values, drop=True):
+        return self(lambda c, v: c < v, *values, drop=drop)
+
+    def lt_or_eq(self, *values, drop=True):
+        return self(lambda c, v: c <= v, *values, drop=drop)
+
+    def between(self, *values, drop=True):
+        return self(lambda c, v: (c >= v[0]) & (c <= v[1]), *values, drop=drop)
+
+    def __eq__(self, values):
+        """Helper operator for the `eq` method."""
+        return self.eq(*self._to_seq(values))
+
+    def __ne__(self, values):
+        """Helper operator for the `neq` method."""
+        return self.neq(*self._to_seq(values))
+
+    def __gt__(self, values):
+        """Helper operator for the `gt` method."""
+        return self.gt(*self._to_seq(values))
+
+    def __ge__(self, values):
+        """Helper operator for the `gt_or_eq` method."""
+        return self.gt_or_eq(*self._to_seq(values))
+
+    def __lt__(self, values):
+        """Helper operator for the `lt` method."""
+        return self.lt(*self._to_seq(values))
+
+    def __le__(self, values):
+        """Helper operator for the `lt_or_eq` method."""
+        return self.lt_or_eq(*self._to_seq(values))
+
+    def __matmul__(self, values):
+        """Helper operator for the `between` method."""
+        return self.between(*self._to_seq(values))
+
+
+def sel(array, *coords):
+    """Make an `SDArraySelector` instance."""
+    return SDArraySelector(array, *coords)

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pandas as pd
+import sdarray as sd
+
+
+# test data for evaluation
+shape = 3600, 100
+date = "2020-01-01"
+label = ["ON,SCI", "OFF,CAL"]
+
+t = pd.date_range(date, periods=shape[0], freq="1s").to_numpy()
+ch = np.arange(shape[1])
+label = "t", np.random.choice(label, shape[0])
+
+da = sd.array(np.random.randn(*shape), t=t, ch=ch, coords={"label": label})
+
+
+# test functions
+def test_eq(n_ch=10):
+    ch_sel = np.random.choice(ch, n_ch, False)
+    da_ans = da.loc[:, ch_sel]
+    da_test = da.sd.where("ch") == ch_sel
+    assert (da_test == da_ans).all()
+
+
+def test_neq(n_ch=10):
+    ch_sel = np.random.choice(ch, n_ch, False)
+    da_ans = da.loc[:, np.setdiff1d(ch, ch_sel)]
+    da_test = da.sd.where("ch") != ch_sel
+    assert (da_test == da_ans).all()
+
+
+def test_gt(ch_max=50):
+    da_ans = da.loc[:, ch[ch > ch_max]]
+    da_test = da.sd.where("ch") > ch_max
+    assert (da_test == da_ans).all()
+
+
+def test_gt_or_eq(ch_max=50):
+    da_ans = da.loc[:, ch[ch >= ch_max]]
+    da_test = da.sd.where("ch") >= ch_max
+    assert (da_test == da_ans).all()
+
+
+def test_lt(ch_max=50):
+    da_ans = da.loc[:, ch[ch < ch_max]]
+    da_test = da.sd.where("ch") < ch_max
+    assert (da_test == da_ans).all()
+
+
+def test_lt_or_eq(ch_max=50):
+    da_ans = da.loc[:, ch[ch <= ch_max]]
+    da_test = da.sd.where("ch") <= ch_max
+    assert (da_test == da_ans).all()
+
+
+def test_between_1d(ch_min=10, ch_max=50):
+    da_ans = da.loc[:, ch[(ch >= ch_min) & (ch <= ch_max)]]
+    da_test = da.sd.where("ch") @ (ch_min, ch_max)
+    assert (da_test == da_ans).all()
+
+
+def test_between_2d(t_min="00:30:00", t_max="00:45:00", ch_min=10, ch_max=50):
+    t_min = np.datetime64(f"{date}T{t_min}")
+    t_max = np.datetime64(f"{date}T{t_max}")
+    t_bool = (t >= t_min) & (t <= t_max)
+    ch_bool = (ch >= ch_min) & (ch <= ch_max)
+
+    da_ans = da.loc[t[t_bool], ch[ch_bool]]
+    da_test = da.sd.where("t", "ch") @ ((t_min, t_max), (ch_min, ch_max))
+    assert (da_test == da_ans).all()
+
+
+def test_contains(label="ON", label_ans="ON,SCI"):
+    da_ans = da[da.label == label_ans]
+    da_test = da.sd.where("label") ** label
+    assert (da_test == da_ans).all()


### PR DESCRIPTION
- Add `sel-by-coord` class to select (slice) an array by coordinate values
- Add `where` function to return a `sel-by-coord` instance
- Update test scripts

```python
new = old.sd.where("id") == [0, 1, 2]
# new = old[(old["id"]==0) | (old["id"]==1) | (old["id"]==2)]
```

Other features are:

```python
# not equal to
old.sd.where("id") != [1, 3]

# less than (or equal to)
old.sd.where("id") < 2
old.sd.where("id") <= 2

# greater than (or equal to)
old.sd.where("id") > 4
old.sd.where("id") >= 4

# between
old.sd.where("dec") @ (-60, -30)
old.sd.where("ra", "dec") @ ((150, 180), (-60, -30))

# containts (only for string coordinate)
old.sd.where("scantype") ** "ON"
```